### PR TITLE
Починка refresh: access-токен и тесты

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .env
 .yml
 
+.vscode
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:latest
+    image: postgres:15
     container_name: postgres_db
     environment:
       POSTGRES_USER: postgres

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -212,6 +212,7 @@ func TestRefreshTokenHandlerSuccess(t *testing.T) {
 	// Подготовка запроса
 	data, _ := json.Marshal(&auth.RefreshTokenRequest{
 		RefreshToken: tokenPair.RefreshToken,
+		AccessToken:  tokenPair.AccessToken,
 	})
 	reader := bytes.NewReader(data)
 
@@ -238,9 +239,10 @@ func TestRefreshTokenHandlerInvalidToken(t *testing.T) {
 	handler, mockDB, cleanup := setupAuthHandler(t)
 	defer cleanup()
 
-	// Подготовка запроса с невалидным токеном
+	// Подготовка запроса с невалидным токеном и добавление обязательного AccessToken
 	data, _ := json.Marshal(&auth.RefreshTokenRequest{
 		RefreshToken: "invalid.refresh.token",
+		AccessToken:  "valid.access.token",
 	})
 	reader := bytes.NewReader(data)
 

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -88,9 +88,10 @@ func (service *AuthService) Login(email, password string) (jwt.JWTData, error) {
 // RefreshTokens - обновление токенов
 func (service *AuthService) RefreshTokens(refreshToken, accessToken string) (*jwt.TokenPair, error) {
 	accessTokenValid, _ := service.JWT.ParseToken(accessToken)
-	if accessTokenValid {
+	if !accessTokenValid {
 		return nil, errors.New(ErrAccessToken)
 	}
+
 	refreshTokenValid, data := service.JWT.ParseRefreshToken(refreshToken)
 	if !refreshTokenValid || data == nil {
 		return nil, errors.New(ErrInvalidRefreshToken)

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -145,15 +145,15 @@ func TestRefreshTokensSuccess(t *testing.T) {
 	// Создаем валидный refresh token
 	validEmail := "test@example.com"
 	jwtService := jwt.NewJWT("test-secret")
-	tokenPair, _ := jwtService.GenerateTokenPair(jwt.JWTData{Email: validEmail})
+	tokenPair, err := jwtService.GenerateTokenPair(jwt.JWTData{Email: validEmail})
+	require.NoError(t, err)
 
 	// Настройка ожиданий для БД
 	mockDB.ExpectQuery(`SELECT (.+) FROM "users" WHERE`).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "email", "password", "username"}).
 			AddRow(1, validEmail, "hashedpassword", "testuser"))
-
 	// Вызываем метод обновления токенов
-	newTokenPair, err := authService.RefreshTokens(tokenPair.AccessToken, tokenPair.RefreshToken)
+	newTokenPair, err := authService.RefreshTokens(tokenPair.RefreshToken, tokenPair.AccessToken)
 
 	require.NoError(t, err)
 	require.NotEmpty(t, newTokenPair.AccessToken)
@@ -168,7 +168,12 @@ func TestRefreshTokensInvalidToken(t *testing.T) {
 	defer cleanup()
 
 	// Вызываем метод обновления токенов с невалидным токеном
-	_, err := authService.RefreshTokens("invalid.access.token", "invalid.refresh.token")
+	validEmail := "test@example.com"
+	jwtService := jwt.NewJWT("test-secret")
+	tokenPair, err := jwtService.GenerateTokenPair(jwt.JWTData{Email: validEmail})
+	require.NoError(t, err)
+
+	_, err = authService.RefreshTokens("invalid.refresh.token", tokenPair.AccessToken)
 
 	// Проверка, что получили ожидаемую ошибку
 
@@ -193,7 +198,7 @@ func TestRefreshTokensUserNotFound(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{}))
 
 	// Вызываем метод обновления токенов
-	_, err := authService.RefreshTokens(tokenPair.AccessToken, tokenPair.RefreshToken)
+	_, err := authService.RefreshTokens(tokenPair.RefreshToken, tokenPair.AccessToken)
 
 	// Проверка, что получили ожидаемую ошибку
 	require.Error(t, err)


### PR DESCRIPTION
- В RefreshTokens была ошибка, неправильно проверялся валидный токен. Теперь исправленою
- В тестах поправил порядок аргументов (refresh, потом access) и довел сценарии до актуальной логики.
- В тестах хендлера в запрос добавил AccessToken, раз он нужен для обновления.

В проекте пока нет описания эндпоинтов — разбирался дольше, чем хотелось бы. Было бы полезно добавить хотя бы краткое API

